### PR TITLE
Add OKP4 testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Nodejumper supports around 17 networks and the number is constantly growing.
     <td>Testnet</td>
     <td>https://nodejumper.io/empower-testnet</td>
   </tr>
+  <tr>
+    <td><img width="50" src="https://raw.githubusercontent.com/nodejumper-org/nodejumper/master/src/assets/img/chain/okp4.webp" alt="OKP4"></td>
+    <td>OKP4</td>
+    <td>Testnet</td>
+    <td>https://nodejumper.io/okp4-testnet</td>
+  </tr>
 </table>
 
 ## Contributors


### PR DESCRIPTION
Make the OKP4 testnet visible  in the `README.md` file by adding [OKP4 testnet](https://nodejumper.io/okp4-testnet) to the table of supported networks table.

<img width="640" alt="image" src="https://user-images.githubusercontent.com/9574336/200393723-90084d2a-9dc4-4a78-aaae-70d5b2096f02.png">

Thanks guys for supporting us, you rock ❤️